### PR TITLE
Pass the Kotlin version as parameter to Gradle 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: 1.8
 
       - name: ${{ matrix.gradle-task }} with Gradle
-        run: ./gradlew ${{ matrix.gradle-task }} --no-build-cache --no-daemon --stacktrace
+        run: ./gradlew ${{ matrix.gradle-task }} --no-build-cache --no-daemon --stacktrace -Psquare.kotlinVersion=${{ matrix.kotlin-version }}
 
   instrumentation-tests:
     name: Instrumentation tests


### PR DESCRIPTION
Pass the Kotlin version as parameter to Gradle to run the build with the desired version in CI.