### PR TITLE
Fix plugin ordering requirements

### DIFF
--- a/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/HephaestusPlugin.kt
+++ b/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/HephaestusPlugin.kt
@@ -44,8 +44,10 @@ open class HephaestusPlugin : Plugin<Project> {
     disableIncrementalKotlinCompilation(project)
     disablePreciseJavaTracking(project)
 
-    // This needs to be disabled, otherwise compiler plugins fail in weird ways when generating stubs.
-    project.extensions.findByType(KaptExtension::class.java)?.correctErrorTypes = false
+    project.pluginManager.withPlugin("org.jetbrains.kotlin.kapt") {
+      // This needs to be disabled, otherwise compiler plugins fail in weird ways when generating stubs.
+      project.extensions.findByType(KaptExtension::class.java)?.correctErrorTypes = false
+    }
 
     project.dependencies.add("api", "$GROUP:annotations:$VERSION")
   }

--- a/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/HephaestusPlugin.kt
+++ b/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/HephaestusPlugin.kt
@@ -28,8 +28,7 @@ open class HephaestusPlugin : Plugin<Project> {
       }
     }
     project.pluginManager.apply {
-      withPlugin("com.android.application", innerApply)
-      withPlugin("com.android.library", innerApply)
+      withPlugin("org.jetbrains.kotlin.android", innerApply)
       withPlugin("org.jetbrains.kotlin.jvm", innerApply)
     }
     project.afterEvaluate {

--- a/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/HephaestusPlugin.kt
+++ b/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/HephaestusPlugin.kt
@@ -27,7 +27,7 @@ open class HephaestusPlugin : Plugin<Project> {
         realApply(project)
       }
     }
-    project.pluginManager.apply {
+    with(project.pluginManager) {
       withPlugin("org.jetbrains.kotlin.android", innerApply)
       withPlugin("org.jetbrains.kotlin.jvm", innerApply)
     }

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -1,7 +1,9 @@
-apply plugin: 'com.android.application'
-apply plugin: 'org.jetbrains.kotlin.android'
-apply plugin: 'org.jetbrains.kotlin.kapt'
-apply plugin: 'com.squareup.hephaestus'
+plugins {
+  id 'com.android.application'
+  id 'org.jetbrains.kotlin.android'
+  id 'org.jetbrains.kotlin.kapt'
+  id 'com.squareup.hephaestus'
+}
 
 android {
   compileSdkVersion 29

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,18 +1,3 @@
-pluginManagement {
-  resolutionStrategy {
-    eachPlugin {
-      String id = requested.id.id
-      if (id.startsWith("com.android")) {
-        useModule("com.android.tools.build:gradle:4.0.0")
-      } else if (id.startsWith("org.jetbrains.kotlin")) {
-        String kotlinVersion = hasProperty('square.kotlinVersion') ?
-            getProperty('square.kotlinVersion') : '1.3.72'
-        useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-      }
-    }
-  }
-}
-
 include ':annotations'
 include ':compiler'
 include ':integration-tests:library'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,18 @@
+pluginManagement {
+  resolutionStrategy {
+    eachPlugin {
+      String id = requested.id.id
+      if (id.startsWith("com.android")) {
+        useModule("com.android.tools.build:gradle:4.0.0")
+      } else if (id.startsWith("org.jetbrains.kotlin")) {
+        String kotlinVersion = hasProperty('square.kotlinVersion') ?
+            getProperty('square.kotlinVersion') : '1.3.72'
+        useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+      }
+    }
+  }
+}
+
 include ':annotations'
 include ':compiler'
 include ':integration-tests:library'


### PR DESCRIPTION
Gradle's `PluginManager.withPlugin(...)` API covers this case, and avoids the need for ordering issues in most cases. Fixes #8 