### PR TITLE
Configure tasks lazily when they're actually needed. 

### DIFF
--- a/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/HephaestusPlugin.kt
+++ b/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/HephaestusPlugin.kt
@@ -37,7 +37,7 @@ open class HephaestusPlugin : Plugin<Project> {
   ) {
     project.tasks
         .withType(KotlinCompile::class.java)
-        .all { compileTask ->
+        .configureEach { compileTask ->
           val checkMixedSourceSet = project.tasks.register(
               compileTask.name + "CheckMixedSourceSetHephaestus",
               CheckMixedSourceSetTask::class.java
@@ -61,7 +61,7 @@ open class HephaestusPlugin : Plugin<Project> {
   ) {
     project.tasks
         .withType(KotlinCompile::class.java)
-        .all { compileTask ->
+        .configureEach { compileTask ->
           val isStubGeneratingTask = compileTask is KaptGenerateStubsTask
 
           if (isStubGeneratingTask) {


### PR DESCRIPTION
This prevents creating task unnecessarily.