### PR TITLE
Use @OptIn(ExperimentalStdlibApi::class) instead of @ExperimentalStdlibApi

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -17,3 +17,11 @@ dependencies {
   testImplementation deps.kotlin.compiler
   testImplementation deps.truth
 }
+
+//noinspection UnnecessaryQualifiedReference
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_1_8
+    freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+  }
+}

--- a/compiler/src/test/java/com/squareup/hephaestus/compiler/ContributesToGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/hephaestus/compiler/ContributesToGeneratorTest.kt
@@ -5,7 +5,6 @@ import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERRO
 import com.tschuchort.compiletesting.KotlinCompilation.Result
 import org.junit.Test
 
-@ExperimentalStdlibApi
 class ContributesToGeneratorTest {
 
   @Test fun `there is no hint for merge annotations`() {

--- a/compiler/src/test/java/com/squareup/hephaestus/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/hephaestus/compiler/TestUtils.kt
@@ -83,7 +83,7 @@ internal val Result.daggerModule4: Class<*>
 internal val Result.innerModule: Class<*>
   get() = classLoader.loadClass("com.squareup.test.ComponentInterface\$InnerModule")
 
-@ExperimentalStdlibApi
+@OptIn(ExperimentalStdlibApi::class)
 internal val Class<*>.hint: KClass<*>?
   get() {
     // The capitalize doesn't make sense, I don't know where this is coming from the compile testing

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -56,8 +56,12 @@ pluginBundle {
   tags = ['dagger2', 'dagger2-android', 'kotlin', 'kotlin-compiler-plugin']
 }
 
-compileKotlin {
-  kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8
+//noinspection UnnecessaryQualifiedReference
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_1_8
+    freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+  }
 }
 
 dependencies {

--- a/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/CheckMixedSourceSet.kt
+++ b/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/CheckMixedSourceSet.kt
@@ -17,7 +17,6 @@ import java.io.File
  * The workaround for now is to set the kotlin.incremental.usePreciseJavaTracking flag to false for
  * these module using this task.
  */
-@ExperimentalStdlibApi
 open class CheckMixedSourceSet(
   private val project: Project,
   private val compileTask: KotlinCompile
@@ -43,6 +42,7 @@ open class CheckMixedSourceSet(
     }
   }
 
+  @OptIn(ExperimentalStdlibApi::class)
   private fun getSourceFilesAndroidProject(): Sequence<File> {
     return project.androidVariants()
         .findVariantForCompileTask(compileTask)

--- a/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/HephaestusPlugin.kt
+++ b/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/HephaestusPlugin.kt
@@ -21,7 +21,6 @@ import java.util.Locale.US
 import java.util.concurrent.atomic.AtomicBoolean
 
 open class HephaestusPlugin : Plugin<Project> {
-  @ExperimentalStdlibApi
   override fun apply(project: Project) {
     val once = AtomicBoolean()
 
@@ -56,7 +55,6 @@ open class HephaestusPlugin : Plugin<Project> {
     }
   }
 
-  @ExperimentalStdlibApi
   private fun realApply(
     project: Project,
     isAndroidProject: Boolean
@@ -72,7 +70,6 @@ open class HephaestusPlugin : Plugin<Project> {
     project.dependencies.add("api", "$GROUP:annotations:$VERSION")
   }
 
-  @ExperimentalStdlibApi
   private fun disablePreciseJavaTracking(
     project: Project
   ) {
@@ -92,8 +89,7 @@ open class HephaestusPlugin : Plugin<Project> {
         }
   }
 
-  @Suppress("UnstableApiUsage")
-  @ExperimentalStdlibApi
+  @OptIn(ExperimentalStdlibApi::class)
   private fun disableIncrementalKotlinCompilation(
     project: Project,
     isAndroidProject: Boolean
@@ -117,6 +113,7 @@ open class HephaestusPlugin : Plugin<Project> {
     // Use this signal to share state between DisableIncrementalCompilationTask and the Kotlin
     // compile task. If the plugin classpath changed, then DisableIncrementalCompilationTask sets
     // the signal to false.
+    @Suppress("UnstableApiUsage")
     val incrementalSignal = project.gradle.sharedServices
         .registerIfAbsent("incrementalSignal", IncrementalSignal::class.java) { }
 
@@ -200,7 +197,7 @@ fun Project.androidVariantsConfigure(action: (BaseVariant) -> Unit) {
   }
 }
 
-@ExperimentalStdlibApi
+@OptIn(ExperimentalStdlibApi::class)
 fun Collection<BaseVariant>.findVariantForCompileTask(
   compileTask: KotlinCompile
 ): BaseVariant = this

--- a/sample/library/build.gradle
+++ b/sample/library/build.gradle
@@ -10,7 +10,8 @@ dependencies {
   kapt deps.dagger2.compiler
 }
 
-compileKotlin {
+//noinspection UnnecessaryQualifiedReference
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
   kotlinOptions {
     freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
   }


### PR DESCRIPTION
Use @OptIn(ExperimentalStdlibApi::class) instead of @ExperimentalStdlibApi to avoid for consumers of the Gradle plugin to add a flag to the Kotlin compiler.