### PR TITLE
Allow generating code in all Kotlin compile tasks

### DIFF
--- a/compiler/src/main/java/com/squareup/hephaestus/compiler/ClassScanner.kt
+++ b/compiler/src/main/java/com/squareup/hephaestus/compiler/ClassScanner.kt
@@ -6,21 +6,17 @@ import org.jetbrains.kotlin.descriptors.PackageViewDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.resolve.DescriptorUtils
-import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
 
-internal class ClassScanner(
-  private val additionalPackages: Collection<String>
-) {
+internal class ClassScanner {
 
   private val cache = mutableMapOf<String, List<ClassDescriptor>>()
 
   /**
    * Returns a list of classes from the dependency graph annotated with `@ContributesTo`. Note that
-   * the list includes inner classes already. It does NOT contain classes having this annotation from
-   * this module. Use [findTopLevelClassesInThisModule] for this purpose instead.
+   * the list includes inner classes already.
    */
-  fun findContributedClassesInDependencyGraph(
+  fun findContributedClasses(
     module: ModuleDescriptor,
     packageName: String = HINT_PACKAGE_PREFIX
   ): List<ClassDescriptor> {
@@ -40,50 +36,6 @@ internal class ClassScanner(
           .map { DescriptorUtils.getClassDescriptorForType(it.type.argumentType()) }
           .filter { it.findAnnotation(contributesToFqName) != null }
           .toList()
-    }
-  }
-
-  /**
-   * Returns a list of top level classes (meaning no inner classes) in this module. Note that the
-   * algorithm for this method takes all used packages from this module and lists all classes within
-   * this package. That means the returned list could include classes from module dependencies in the
-   * same package.
-   */
-  fun findTopLevelClassesInThisModule(
-    module: ModuleDescriptor
-  ): List<ClassDescriptor> {
-    return additionalPackages
-        .flatMap { packageString ->
-          cache.getOrPut(packageString) {
-            additionalPackages
-                .map { module.getPackage(FqName(packageString)) }
-                .flatMap { packageDescriptor ->
-                  packageDescriptor
-                      .memberScope
-                      .getContributedDescriptors(DescriptorKindFilter.CLASSIFIERS) { name ->
-                        val nameString = name.asString()
-                        nameString != "R" && nameString != "BuildConfig"
-                      }
-                }
-                .filterIsInstance<ClassDescriptor>()
-                .filterNot {
-                  // Exclude generated Dagger components. There's no need to look at them. Interestingly,
-                  // they cause some recursive errors when compiling inner classes.
-                  it.isGeneratedDaggerComponent()
-                }
-          }
-        }
-  }
-
-  /**
-   * Returns all inner classes for the given descriptor. The result list does NOT contain [descriptor]
-   * itself.
-   */
-  fun innerClasses(descriptor: ClassDescriptor): List<ClassDescriptor> {
-    return cache.getOrPut(descriptor.fqNameSafe.asString()) {
-      descriptor.unsubstitutedInnerClassesScope
-          .getContributedDescriptors(DescriptorKindFilter.CLASSIFIERS)
-          .filterIsInstance<ClassDescriptor>()
     }
   }
 }

--- a/compiler/src/main/java/com/squareup/hephaestus/compiler/ContributeToGenerator.kt
+++ b/compiler/src/main/java/com/squareup/hephaestus/compiler/ContributeToGenerator.kt
@@ -5,6 +5,8 @@ import dagger.Module
 import org.jetbrains.kotlin.analyzer.AnalysisResult
 import org.jetbrains.kotlin.analyzer.AnalysisResult.RetryWithAdditionalRoots
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.container.ComponentProvider
+import org.jetbrains.kotlin.context.ProjectContext
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.FqName
@@ -29,6 +31,19 @@ internal class ContributeToGenerator(
 ) : AnalysisHandlerExtension {
 
   private var didRecompile = false
+
+  override fun doAnalysis(
+    project: Project,
+    module: ModuleDescriptor,
+    projectContext: ProjectContext,
+    files: Collection<KtFile>,
+    bindingTrace: BindingTrace,
+    componentProvider: ComponentProvider
+  ): AnalysisResult? {
+    // Tell the compiler that we have something to do in the analysisCompleted() method if
+    // necessary.
+    return if (!didRecompile) AnalysisResult.EMPTY else null
+  }
 
   override fun analysisCompleted(
     project: Project,

--- a/compiler/src/main/java/com/squareup/hephaestus/compiler/HephaestusCommandLineProcessor.kt
+++ b/compiler/src/main/java/com/squareup/hephaestus/compiler/HephaestusCommandLineProcessor.kt
@@ -10,9 +10,6 @@ import org.jetbrains.kotlin.config.CompilerConfigurationKey
 internal const val srcGenDirName = "src-gen-dir"
 internal val srcGenDirKey = CompilerConfigurationKey.create<String>("hephaestus $srcGenDirName")
 
-internal const val skipAnalysisName = "skip-analysis"
-internal val skipAnalysisKey = CompilerConfigurationKey.create<Boolean>("hephaestus $skipAnalysisName")
-
 /**
  * Parses arguments from the Gradle plugin for the compiler plugin.
  */
@@ -27,14 +24,6 @@ class HephaestusCommandLineProcessor : CommandLineProcessor {
           description = "Path to directory in which Hephaestus specific code should be generated",
           required = true,
           allowMultipleOccurrences = false
-      ),
-      CliOption(
-          optionName = skipAnalysisName,
-          valueDescription = "<true|false>",
-          description = "Whether this plugin should skip the analysis phase. This happens during " +
-              "stub generation automatically and this option is helpful to test this scenario.",
-          required = false,
-          allowMultipleOccurrences = false
       )
   )
 
@@ -45,7 +34,6 @@ class HephaestusCommandLineProcessor : CommandLineProcessor {
   ) {
     when (option.optionName) {
       srcGenDirName -> configuration.put(srcGenDirKey, value)
-      skipAnalysisName -> configuration.put(skipAnalysisKey, value.toBoolean())
     }
   }
 }

--- a/compiler/src/main/java/com/squareup/hephaestus/compiler/ModuleMerger.kt
+++ b/compiler/src/main/java/com/squareup/hephaestus/compiler/ModuleMerger.kt
@@ -53,16 +53,8 @@ internal class ModuleMerger(
           ?.map { it.toType(codegen) }
 
     val modules = classScanner
-        .findContributedClassesInDependencyGraph(codegen.descriptor.module)
+        .findContributedClasses(codegen.descriptor.module)
         .asSequence()
-        .plus(
-            classScanner.findTopLevelClassesInThisModule(codegen.descriptor.module)
-                .asSequence()
-                .flatMap {
-                  classScanner.innerClasses(it)
-                      .asSequence() + it
-                }
-        )
         .mapNotNull {
           val contributesAnnotation =
             it.findAnnotation(contributesToFqName, scope = scope) ?: return@mapNotNull null

--- a/compiler/src/test/java/com/squareup/hephaestus/compiler/ContributesToGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/hephaestus/compiler/ContributesToGeneratorTest.kt
@@ -2,7 +2,6 @@ package com.squareup.hephaestus.compiler
 
 import com.google.common.truth.Truth.assertThat
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
-import com.tschuchort.compiletesting.KotlinCompilation.Result
 import org.junit.Test
 
 class ContributesToGeneratorTest {
@@ -164,9 +163,4 @@ class ContributesToGeneratorTest {
       }
     }
   }
-
-  private fun compile(
-    source: String,
-    block: Result.() -> Unit = { }
-  ): Result = compile(source, skipAnalysis = false, block = block)
 }

--- a/compiler/src/test/java/com/squareup/hephaestus/compiler/MergeModulesTest.kt
+++ b/compiler/src/test/java/com/squareup/hephaestus/compiler/MergeModulesTest.kt
@@ -2,22 +2,9 @@ package com.squareup.hephaestus.compiler
 
 import com.google.common.truth.Truth.assertThat
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
-import com.tschuchort.compiletesting.KotlinCompilation.Result
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
 
-@RunWith(Parameterized::class)
-class MergeModulesTest(
-  private val skipAnalysis: Boolean
-) {
-  companion object {
-    @Parameters(name = "skipAnalysis: {0}")
-    @JvmStatic fun annotationClasses(): Collection<Any> {
-      return listOf(true, false)
-    }
-  }
+class MergeModulesTest {
 
   @Test fun `Dagger modules are empty without arguments`() {
     compile(
@@ -398,9 +385,4 @@ class MergeModulesTest(
           .containsExactly(innerModule.kotlin)
     }
   }
-
-  private fun compile(
-    source: String,
-    block: Result.() -> Unit = { }
-  ): Result = compile(source, skipAnalysis, block = block)
 }

--- a/compiler/src/test/java/com/squareup/hephaestus/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/hephaestus/compiler/TestUtils.kt
@@ -16,7 +16,6 @@ import kotlin.reflect.KClass
 
 internal fun compile(
   source: String,
-  skipAnalysis: Boolean,
   block: Result.() -> Unit = { }
 ): Result {
   return KotlinCompilation()
@@ -29,11 +28,6 @@ internal fun compile(
         commandLineProcessors = listOf(commandLineProcessor)
 
         pluginOptions = listOf(
-            PluginOption(
-                pluginId = commandLineProcessor.pluginId,
-                optionName = skipAnalysisName,
-                optionValue = skipAnalysis.toString()
-            ),
             PluginOption(
                 pluginId = commandLineProcessor.pluginId,
                 optionName = srcGenDirName,

--- a/sample/app/src/main/java/com/squareup/hephaestus/sample/RandomModule.kt
+++ b/sample/app/src/main/java/com/squareup/hephaestus/sample/RandomModule.kt
@@ -1,0 +1,18 @@
+package com.squareup.hephaestus.sample
+
+import com.squareup.hephaestus.annotations.ContributesTo
+import com.squareup.scopes.AppScope
+import dagger.Module
+import dagger.Provides
+import javax.inject.Named
+
+@Module
+@ContributesTo(AppScope::class)
+object RandomModule {
+  @Provides @Named("random") fun provideString(): String = "Hello!"
+}
+
+@ContributesTo(AppScope::class)
+interface RandomComponent {
+  @Named("random") fun string(): String
+}

--- a/sample/app/src/test/java/com/squareup/hephaestus/sample/RandomModuleTest.kt
+++ b/sample/app/src/test/java/com/squareup/hephaestus/sample/RandomModuleTest.kt
@@ -1,0 +1,12 @@
+package com.squareup.hephaestus.sample
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class RandomModuleTest {
+  @Test fun `module in this app module is contributed`() {
+    val component = DaggerAppComponent.create() as RandomComponent
+
+    assertThat(component.string()).isEqualTo(RandomModule.provideString())
+  }
+}


### PR DESCRIPTION
This change removes some workarounds for discovering contributed classes in the same module as components are merged. It also allows implementing other features that require more code generating in the future. 