### PR TITLE
Fixes Configuration caching issues

### DIFF
--- a/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/DisableIncrementalCompilationTask.kt
+++ b/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/DisableIncrementalCompilationTask.kt
@@ -5,8 +5,6 @@ package com.squareup.hephaestus.plugin
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildService
-import org.gradle.api.services.BuildServiceParameters.None
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
@@ -37,9 +35,4 @@ abstract class DisableIncrementalCompilationTask : DefaultTask() {
     // in the classpath, then this task wouldn't run at all and be skipped.
     incrementalSignal.get().incremental[projectPath] = false
   }
-}
-
-/** This signal is used to share state between the task above and Kotlin compile tasks. */
-abstract class IncrementalSignal : BuildService<None> {
-  val incremental = mutableMapOf<String, Boolean?>()
 }

--- a/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/IncrementalSignal.kt
+++ b/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/IncrementalSignal.kt
@@ -1,0 +1,9 @@
+package com.squareup.hephaestus.plugin
+
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters.None
+
+/** This signal is used to share state between the task above and Kotlin compile tasks. */
+abstract class IncrementalSignal : BuildService<None> {
+  val incremental = mutableMapOf<String, Boolean?>()
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.squareup.hephaestus
-VERSION_NAME=1.0.1
+VERSION_NAME=1.0.1-SNAPSHOT
 
 POM_DESCRIPTION=A Kotlin compiler plugin to make dependency injection with Dagger 2 easier by automatically merging Dagger modules and component interfaces.
 POM_INCEPTION_YEAR=2020


### PR DESCRIPTION
Using versions: [Kotlin:1.4-M3, Gradle:6.5, AGP 4.1 beta 04], I could detect some issues when running instant execution: 

```
428 problems were found reusing the configuration cache, 4 of which seem unique.
- field '$disableIncrementalCompilationTaskProvider' from type 'com.squareup.hephaestus.plugin.HephaestusPlugin$disableIncrementalKotlinCompilation$disableIncrementalCompilationAction$1$1': cannot deserialize object of type 'org.gradle.api.Task' as these are not supported with the configuration cache.
  See https://docs.gradle.org/6.6-rc-1/userguide/configuration_cache.html#config_cache:requirements:task_access
- field '$disableIncrementalCompilationTaskProvider' from type 'com.squareup.hephaestus.plugin.HephaestusPlugin$disableIncrementalKotlinCompilation$disableIncrementalCompilationAction$1$1': value 'undefined' is not assignable to 'org.gradle.api.tasks.TaskProvider'
- field '$project' from type 'com.squareup.hephaestus.plugin.HephaestusPlugin$disableIncrementalKotlinCompilation$disableIncrementalCompilationAction$1': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.
  See https://docs.gradle.org/6.6-rc-1/userguide/configuration_cache.html#config_cache:requirements:disallowed_types
- field '$project' from type 'com.squareup.hephaestus.plugin.HephaestusPlugin$disablePreciseJavaTracking$1': cannot deserialize object of type 'org.gradle.api.Project' as these are not supported with the configuration cache.
  See https://docs.gradle.org/6.6-rc-1/userguide/configuration_cache.html#config_cache:requirements:disallowed_types
```

This PR fixes the various issues. Thx to @bamboo for the guidance