### PR TITLE
Set an explicit target and source Java version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,11 @@ subprojects {
     }
   }
 
+  tasks.withType(JavaCompile).configureEach {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+  }
+
   //noinspection UnnecessaryQualifiedReference
   tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -62,6 +62,11 @@ pluginBundle {
   tags = ['dagger2', 'dagger2-android', 'kotlin', 'kotlin-compiler-plugin']
 }
 
+tasks.withType(JavaCompile).configureEach {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 //noinspection UnnecessaryQualifiedReference
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
   kotlinOptions {


### PR DESCRIPTION
Avoid relying on the currently configured JDK.