### PR TITLE
Disallow including and excluding types at the same time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next Version
 
-*
+* Ensure that types cannot be included and excluded at the same time, which leads to unexpected results.
 
 ## 1.0.3-1.4-M3 (2020-07-17)
 

--- a/compiler/src/main/java/com/squareup/hephaestus/compiler/ModuleMerger.kt
+++ b/compiler/src/main/java/com/squareup/hephaestus/compiler/ModuleMerger.kt
@@ -110,6 +110,16 @@ internal class ModuleMerger(
         ?.map { it.toType(codegen) }
         ?: emptyList()
 
+    if (predefinedModules != null) {
+      val intersect = predefinedModules.intersect(excludedModules)
+      if (intersect.isNotEmpty()) {
+        throw HephaestusCompilationException(
+            codegen.descriptor, "${codegen.descriptor.name} includes and excludes modules " +
+            "at the same time: ${intersect.joinToString { it.className }}"
+        )
+      }
+    }
+
     val contributedModules = modules
         .map { it.first }
         .map { codegen.typeMapper.mapType(it) }

--- a/compiler/src/test/java/com/squareup/hephaestus/compiler/ModuleMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/hephaestus/compiler/ModuleMergerTest.kt
@@ -331,40 +331,6 @@ class ModuleMergerTest(
     }
   }
 
-  @Test fun `predefined modules are not excluded`() {
-    compile(
-        """
-        package com.squareup.test
-
-        import com.squareup.hephaestus.annotations.ContributesTo
-        $import
-
-        @ContributesTo(Any::class)
-        @dagger.Module
-        abstract class DaggerModule1
-
-        @ContributesTo(Any::class)
-        @dagger.Module
-        abstract class DaggerModule2 
-
-        $annotation(
-            scope = Any::class,
-            modules = [
-              DaggerModule1::class
-            ],
-            exclude = [
-              DaggerModule1::class,
-              DaggerModule2::class
-            ]
-        )
-        interface ComponentInterface
-    """
-    ) {
-      val component = componentInterface.anyDaggerComponent
-      assertThat(component.modules).containsExactly(daggerModule1.kotlin)
-    }
-  }
-
   @Test fun `modules are added to components with corresponding scope`() {
     compile(
         """
@@ -497,6 +463,35 @@ class ModuleMergerTest(
     ) {
       assertThat(exitCode).isEqualTo(INTERNAL_ERROR)
       assertThat(messages).contains("File being compiled: (10,18)")
+    }
+  }
+
+  @Test fun `a module is not allowed to be included and excluded`() {
+    compile(
+        """
+        package com.squareup.test
+
+        import com.squareup.hephaestus.annotations.ContributesTo
+        $import
+
+        @ContributesTo(Any::class)
+        @dagger.Module
+        abstract class DaggerModule1
+
+        $annotation(
+            scope = Any::class,
+            modules = [
+              DaggerModule1::class
+            ],
+            exclude = [
+              DaggerModule1::class
+            ]
+        )
+        interface ComponentInterface
+    """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(messages).contains("Source.kt: (19, 11)")
     }
   }
 


### PR DESCRIPTION
Ensure that types cannot be included and excluded at the same time, which leads to unexpected results.