### PR TITLE
Introduces a service registry for the incrementalSignal service.

### DIFF
--- a/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/DisableIncrementalCompilationTask.kt
+++ b/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/DisableIncrementalCompilationTask.kt
@@ -4,10 +4,8 @@ package com.squareup.hephaestus.plugin
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -25,14 +23,13 @@ abstract class DisableIncrementalCompilationTask : DefaultTask() {
   @get:OutputFile @get:Optional
   val someFile = File(project.buildDir, "not-existing-file-because-gradle-needs-an-output")
 
-  @get:Internal
-  abstract val incrementalSignal: Property<IncrementalSignal>
-
-  private val projectPath = project.path
+  private val serviceKey: IncrementalSignalServiceKey = IncrementalSignalServiceKey(project.path)
 
   @TaskAction fun toggleFlag() {
     // Disable incremental compilation if something in the classpath changed. If nothing has changed
     // in the classpath, then this task wouldn't run at all and be skipped.
-    incrementalSignal.get().incremental[projectPath] = false
+    useIncrementalSignalService(serviceKey) {
+      it.incremental = false
+    }
   }
 }

--- a/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/IncrementalSignal.kt
+++ b/gradle-plugin/src/main/java/com/squareup/hephaestus/plugin/IncrementalSignal.kt
@@ -1,9 +1,78 @@
+@file:Suppress("UnstableApiUsage")
+
 package com.squareup.hephaestus.plugin
 
+import com.android.build.gradle.internal.workeractions.WorkerActionServiceRegistry
+import com.android.ide.common.process.ProcessException
+import com.google.common.io.Closer
+import org.gradle.api.Project
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters.None
+import java.io.IOException
+import java.util.UUID
+
+/** Used to get unique build service name. Each class loader will initialize it's onw version. */
+private val HEPHAESTUS_INCREMENTAL_SIGNAL_BUILD_SERVICE_NAME =
+    "hephaestus-incremental-signal-build-service" + UUID.randomUUID().toString()
+
+/**
+ * Registers incremental signal build service and returns a service key that can be used to access
+ * the service later.
+ */
+fun registerIncrementalSignalBuildService(project: Project): IncrementalSignalServiceKey {
+  val buildServiceProvider = project.gradle.sharedServices.registerIfAbsent(
+      HEPHAESTUS_INCREMENTAL_SIGNAL_BUILD_SERVICE_NAME,
+      IncrementalSignalBuildService::class.java
+  ) {}
+  return buildServiceProvider.get().registerIncrementalSignalService(project.path)
+}
+
+/**
+ * Service registry used to store IncrementalSignal services so they are accessible from the worker
+ * actions.
+ */
+var incrementalSignalServiceRegistry: WorkerActionServiceRegistry = WorkerActionServiceRegistry()
+
+/** Intended for use from worker actions. */
+@Throws(ProcessException::class, IOException::class)
+fun useIncrementalSignalService(
+    incrementalSignalServiceKey: IncrementalSignalServiceKey,
+    serviceRegistry: WorkerActionServiceRegistry = incrementalSignalServiceRegistry,
+    block: (IncrementalSignalService) -> Unit
+) = serviceRegistry.getService(incrementalSignalServiceKey).service.let(block)
+
+fun getIncrementalSignalService(
+    incrementalSignalServiceKey: IncrementalSignalServiceKey,
+    serviceRegistry: WorkerActionServiceRegistry = incrementalSignalServiceRegistry
+): IncrementalSignalService = serviceRegistry.getService(incrementalSignalServiceKey).service
+
+data class IncrementalSignalServiceKey(val projectPath: String)
+  : WorkerActionServiceRegistry.ServiceKey<IncrementalSignalService> {
+  override val type: Class<IncrementalSignalService> get() = IncrementalSignalService::class.java
+}
+
+data class IncrementalSignalService(var incremental: Boolean? = null)
 
 /** This signal is used to share state between the task above and Kotlin compile tasks. */
-abstract class IncrementalSignal : BuildService<None> {
-  val incremental = mutableMapOf<String, Boolean?>()
+abstract class IncrementalSignalBuildService : BuildService<None>, AutoCloseable {
+  private val registeredServices = mutableSetOf<IncrementalSignalServiceKey>()
+  private val closer = Closer.create()
+
+  @Synchronized
+  fun registerIncrementalSignalService(
+      projectPath: String,
+      serviceRegistry: WorkerActionServiceRegistry = incrementalSignalServiceRegistry
+  ): IncrementalSignalServiceKey {
+    val key = IncrementalSignalServiceKey(projectPath)
+
+    if (registeredServices.add(key)) {
+      closer.register(serviceRegistry.registerServiceAsCloseable(key, IncrementalSignalService()))
+    }
+
+    return key
+  }
+
+  override fun close() {
+    closer.close()
+  }
 }


### PR DESCRIPTION
This fixes an issue since, if using modern plugin syntax, plugins run in
their own class loader, meaning that the same class can't be used across
projects. This breaks the incremental signal up per project, using a 
WorkerServiceRegistry so that it can be accessed by multiple tasks
within a project.

## Rationale

I suspect that the issue revealed in #31 is related to Gradle's [classloader isolation](https://docs.gradle.org/current/javadoc/org/gradle/workers/WorkerExecutor.html#classLoaderIsolation-org.gradle.api.Action-).  The fact that it works if you add the plugin as a classpath dependency in the buildscript, but doesn't if you add it using modern plugin syntax suggests that to be the case.

I believe that since the plugin is attempting to access the incremental signal from the `KotlinCompile` task, which uses an isolated classpath (my assumption), it receives an IncrementalSignal from a different classloader, which means it can't use the class.

This approach is modeled that used by aapt in the Android gradle plugin. Instead of using a shared BuildService that's accessed from multiple projects and tasks, this uses the build service to register a simple `IncrementalSignalService` with a `WorkerActionServiceRegistry`.  This allows the "service" to be shared among different tasks.

## Testing

This is a bit of a pain to test, but I've set up a [git repository](https://github.com/rharter/hephaestus-issue31) for it.

1. Check out the test repository.
2. Run `./gradlew assemble`
3. Notice the build fails with the following message:

```
Could not determine the dependencies of task ':module1:compileKotlin'.
> Could not create task ':module1:compileKotlinCheckIncrementalCompilationHephaestus'.
   > Cannot set the value of task ':module1:compileKotlinCheckIncrementalCompilationHephaestus' property 'incrementalSignal' of type com.squareup.hephaestus.plugin.IncrementalSignal using a provider of type com.squareup.hephaestus.plugin.IncrementalSignal.
```

4. Update the version of this branch in gradle.properties to `1.0.4-31-SNAPSHOT`, build and deploy to maven local.
5. Switch the plugin imports in the test project's `:app`, `:module1` and `:module2` build files to comment the 1.0.3 version and uncomment the 1.0.4-31-SNAPSHOT variant. (IDEA "Replace in path" makes this much easier)
6. Run the build again with `./gradlew assemble`.
7. The build now succeeds.

Fixes #31 